### PR TITLE
Possible fix for #21

### DIFF
--- a/Pyrlang/Dist/base_connection.py
+++ b/Pyrlang/Dist/base_connection.py
@@ -154,7 +154,11 @@ class BaseConnection:
         from Pyrlang import node
         the_node = node.Node.singleton
 
-        if ctrl_msg_type in [CONTROL_TERM_SEND, CONTROL_TERM_REG_SEND]:
+        if ctrl_msg_type == CONTROL_TERM_SEND:
+            return the_node.send(sender=None,
+                                 receiver=control_term[2],
+                                 message=msg_term)
+        elif ctrl_msg_type == CONTROL_TERM_REG_SEND:
             return the_node.send(sender=control_term[1],
                                  receiver=control_term[3],
                                  message=msg_term)


### PR DESCRIPTION
So I'm not that into what the control messages means, but when looking at them it seems like the sender isn't available for ``CTRL_TERM_SEND`` as it is for ``CTRL_TERM_REG_SEND``. Since in this example the receiver is a local process the sender isn't actually necessary so I just skipped it.

**NOTE** since I don't know the full meaning of ``CTRL_TERM_SEND`` I'm not sure if the receiver will always be a local process, if not we need to elaborate more on this one.